### PR TITLE
Add XML validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # jsonValide
-Validation d'un json avec son modèle XSD
+Validation d'un fichier XML avec son schema XSD
+
+## Utilisation
+
+```bash
+python xml_validate.py mon_fichier.xml mon_schema.xsd
+```
+

--- a/xml_validate.py
+++ b/xml_validate.py
@@ -1,0 +1,43 @@
+import argparse
+from lxml import etree
+
+
+def validate_xml(xml_path: str, xsd_path: str) -> bool:
+    """Validate an XML file against an XSD schema.
+
+    Args:
+        xml_path: Path to the XML file.
+        xsd_path: Path to the XSD schema file.
+
+    Returns:
+        True if the XML is valid, False otherwise.
+    """
+    with open(xsd_path, 'rb') as xsd_file:
+        schema_doc = etree.parse(xsd_file)
+        schema = etree.XMLSchema(schema_doc)
+
+    with open(xml_path, 'rb') as xml_file:
+        xml_doc = etree.parse(xml_file)
+
+    valid = schema.validate(xml_doc)
+    if not valid:
+        for error in schema.error_log:
+            print(error.message)
+    return valid
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate an XML file against an XSD schema")
+    parser.add_argument("xml", help="Path to the XML file")
+    parser.add_argument("xsd", help="Path to the XSD schema file")
+    args = parser.parse_args()
+
+    if validate_xml(args.xml, args.xsd):
+        print("XML is valid.")
+    else:
+        print("XML is invalid.")
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add command line script `xml_validate.py` that validates XML files against an XSD schema
- document usage in README

## Testing
- `python -m py_compile xml_validate.py`

------
https://chatgpt.com/codex/tasks/task_e_6876786e1a248331a318f3324bbcda80