### PR TITLE
Improve validation messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # jsonValide
-Validation d'un json avec son modèle XSD
+Validation d'un fichier XML avec son schéma XSD
+
+## Utilisation
+
+```bash
+python xml_validate.py mon_fichier.xml mon_schema.xsd
+```
+
+En cas d'erreur de validation, les messages affichent la ligne et la colonne
+où le problème est survenu.
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Validation d'un fichier XML avec son schéma XSD
 python xml_validate.py mon_fichier.xml mon_schema.xsd
 ```
 
-En cas d'erreur de validation, les messages affichent la ligne et la colonne
-où le problème est survenu.
+En cas d'erreur de validation, chaque message indique la ligne et la colonne
+du problème, suivies du contenu de la ligne pour faciliter le diagnostic.
 

--- a/xml_validate.py
+++ b/xml_validate.py
@@ -1,0 +1,43 @@
+import argparse
+from lxml import etree
+
+
+def validate_xml(xml_path: str, xsd_path: str) -> bool:
+    """Validate an XML file against an XSD schema.
+
+    Args:
+        xml_path: Path to the XML file.
+        xsd_path: Path to the XSD schema file.
+
+    Returns:
+        True if the XML is valid, False otherwise.
+    """
+    with open(xsd_path, 'rb') as xsd_file:
+        schema_doc = etree.parse(xsd_file)
+        schema = etree.XMLSchema(schema_doc)
+
+    with open(xml_path, 'rb') as xml_file:
+        xml_doc = etree.parse(xml_file)
+
+    valid = schema.validate(xml_doc)
+    if not valid:
+        for error in schema.error_log:
+            print(f"Line {error.line}, column {error.column}: {error.message}")
+    return valid
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate an XML file against an XSD schema")
+    parser.add_argument("xml", help="Path to the XML file")
+    parser.add_argument("xsd", help="Path to the XSD schema file")
+    args = parser.parse_args()
+
+    if validate_xml(args.xml, args.xsd):
+        print("XML is valid.")
+    else:
+        print("XML is invalid.")
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/xml_validate.py
+++ b/xml_validate.py
@@ -21,8 +21,17 @@ def validate_xml(xml_path: str, xsd_path: str) -> bool:
 
     valid = schema.validate(xml_doc)
     if not valid:
+        lines: list[str]
+        with open(xml_path, 'r', encoding="utf-8", errors="ignore") as f:
+            lines = f.readlines()
+
         for error in schema.error_log:
             print(f"Line {error.line}, column {error.column}: {error.message}")
+            if 0 < error.line <= len(lines):
+                problem_line = lines[error.line - 1].rstrip("\n")
+                pointer = " " * (max(error.column - 1, 0)) + "^"
+                print(problem_line)
+                print(pointer)
     return valid
 
 


### PR DESCRIPTION
## Summary
- enhance `xml_validate.py` error output to show line and column numbers
- update README about detailed validation errors

## Testing
- `python -m py_compile xml_validate.py`


------
https://chatgpt.com/codex/tasks/task_e_6876786e1a248331a318f3324bbcda80